### PR TITLE
replace nodejs image link

### DIFF
--- a/content/prerequisites/deploynode.md
+++ b/content/prerequisites/deploynode.md
@@ -11,6 +11,8 @@ Let's start by creating a new namespace and a deployment for the NodeJs applicat
 
 
 ```bash
+NODEJS_ECR_REPO=$(jq < cfn-output.json -r '.NodeJSEcrRepo')
+
 kubectl create namespace appmesh-workshop-ns
 
 # Create directory for eks scripts
@@ -41,7 +43,7 @@ spec:
         app: nodejs-app
     spec:
       containers:
-      - image: aws-containers/ecsdemo-nodejs:latest
+      - image: $NODEJS_ECR_REPO:latest
         imagePullPolicy: Always
         name: nodejs-app
         ports:


### PR DESCRIPTION
replaced broken dockerhub image link with nodejs image pushed to ECR in the previous step

*Issue #, if available:*

*Description of changes:*
Added reference to ECR Repo and Image to replace dead link to dockerhub

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
