### PR TITLE
Change ECR Login Command

### DIFF
--- a/content/prerequisites/bootstrapsh.md
+++ b/content/prerequisites/bootstrapsh.md
@@ -142,7 +142,7 @@ cat > ~/environment/scripts/build-containers <<-"EOF"
 CRYSTAL_ECR_REPO=$(jq < cfn-output.json -r '.CrystalEcrRepo')
 NODEJS_ECR_REPO=$(jq < cfn-output.json -r '.NodeJSEcrRepo')
 
-$(aws ecr get-login --no-include-email)
+$(aws ecr get-login-password | docker login --username AWS --password-stdin $CRYSTAL_ECR_REPO)
 
 docker build -t crystal-service ecsdemo-crystal
 docker tag crystal-service:latest $CRYSTAL_ECR_REPO:vanilla


### PR DESCRIPTION
*Issue #, if available:*

The current command `aws ecr get-login --no-include-email` is no longer valid. Image push will fail with error `no basic auth credentials`

*Description of changes:*

Change ECR login command


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
