### PR TITLE
Apply the Virtual Gateway manifest file

### DIFF
--- a/content/virtualgateway/nodejs-ingress.md
+++ b/content/virtualgateway/nodejs-ingress.md
@@ -86,6 +86,8 @@ spec:
             name: nodejs
 ---
 EOF
+
+kubectl apply -f ~/environment/eks-scripts/app-mesh-virtual-gateway.yml
 ```
 If you take a close look at the previous manifest file, you will notice we added one GatewayRoute with a single route for path /eks. In practical terms this means any requests that arrive at the NLB with path /eks will get rerouted to the Virtual Service nodeJS.
 


### PR DESCRIPTION
kubectl command to apply the manifest file to the EKS cluster, without it there is no ingress to test ...

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
