### PR TITLE
Docker & ECR fixes

### DIFF
--- a/content/prerequisites/bootstrapsh.md
+++ b/content/prerequisites/bootstrapsh.md
@@ -142,7 +142,7 @@ cat > ~/environment/scripts/build-containers <<-"EOF"
 CRYSTAL_ECR_REPO=$(jq < cfn-output.json -r '.CrystalEcrRepo')
 NODEJS_ECR_REPO=$(jq < cfn-output.json -r '.NodeJSEcrRepo')
 
-$(aws ecr get-login --no-include-email)
+aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin $CRYSTAL_ECR_REPO
 
 docker build -t crystal-service ecsdemo-crystal
 docker tag crystal-service:latest $CRYSTAL_ECR_REPO:vanilla


### PR DESCRIPTION
Please add Docker installation as requirement, the build-containers script fails due to it

"aws ecr" used old syntax AWS CLI version 1 which does not work anymore

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
