### PR TITLE
Update deploycfn.md CFN_TEMPLATE check

### DIFF
--- a/content/prerequisites/deploycfn.md
+++ b/content/prerequisites/deploycfn.md
@@ -19,7 +19,7 @@ IAM_ROLE=$(curl -s 169.254.169.254/latest/meta-data/iam/info | \
   jq -r '.InstanceProfileArn' | cut -d'/' -f2)
 
 #Check if the template is already deployed. If not, deploy it
-CFN_TEMPLATE=$(aws cloudformation list-stacks | jq -c '.StackSummaries[].StackName | select( . == "appmesh-workshop" )')
+CFN_TEMPLATE=$(aws cloudformation list-stacks --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE | jq -c '.StackSummaries[].StackName | select( . == "appmesh-workshop" )')
 
 if [ -z "$CFN_TEMPLATE" ]
 then


### PR DESCRIPTION
Added status filter to check if the template is already deployed with completed status. Allows a previously deleted "appmesh-workshop" stack to be recreated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
