### PR TITLE
Fixed the location to fetch eksctl

### DIFF
--- a/content/prerequisites/installtools.md
+++ b/content/prerequisites/installtools.md
@@ -29,7 +29,7 @@ sudo chmod +x /usr/local/bin/kubectl
 echo 'source <(kubectl completion bash)' >>~/.bashrc
 source ~/.bashrc
 
-curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
 sudo mv -v /tmp/eksctl /usr/local/bin
 
 if ! [ -x "$(command -v jq)" ] || ! [ -x "$(command -v envsubst)" ] || ! [ -x "$(command -v kubectl)" ] || ! [ -x "$(command -v eksctl)" ] || ! [ -x "$(command -v ssm-cli)" ]; then


### PR DESCRIPTION
Issue:  The instructions for fetching (via curl) the eksctl binary tar.gz fails.  

Error:  File not found.  Script fails and terminates

Analysis:  The location in the curl command was inaccurate. 

Fix: I fixed it to the following location, which corrected the error 
("https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz")

Results:  No error, eksctl tar.gz is fetched and the script continues to run successfully