### PR TITLE
Update working budy verison to 3.0.0

### DIFF
--- a/templates/appmesh-baseline.yml
+++ b/templates/appmesh-baseline.yml
@@ -886,7 +886,7 @@ Resources:
                   cd /tmp/ruby-build
                   ./install.sh
 
-                  rbenv install 2.5.1 && rbenv global 2.5.1
+                  rbenv install 3.0.0 && rbenv global 3.0.0
 
                   # Install rails and bundler
                   gem install --force rails:4.2.10 bundler:1.17.3


### PR DESCRIPTION
Original ruby version 2.5.1 cannot pass security check, so would being blocked here. Update to 3.0.0 or higher.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
