### PR TITLE
Update installtools.md to download eksctl from eksctl-io instead of w…

### DIFF
--- a/content/prerequisites/installtools.md
+++ b/content/prerequisites/installtools.md
@@ -29,8 +29,18 @@ sudo chmod +x /usr/local/bin/kubectl
 echo 'source <(kubectl completion bash)' >>~/.bashrc
 source ~/.bashrc
 
-curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-sudo mv -v /tmp/eksctl /usr/local/bin
+# for ARM systems, set ARCH to: `arm64`, `armv6` or `armv7`
+ARCH=amd64
+PLATFORM=$(uname -s)_$ARCH
+
+curl -sLO "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$PLATFORM.tar.gz"
+
+# (Optional) Verify checksum
+curl -sL "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_checksums.txt" | grep $PLATFORM | sha256sum --check
+
+tar -xzf eksctl_$PLATFORM.tar.gz -C /tmp && rm eksctl_$PLATFORM.tar.gz
+
+sudo mv /tmp/eksctl /usr/local/bin
 
 if ! [ -x "$(command -v jq)" ] || ! [ -x "$(command -v envsubst)" ] || ! [ -x "$(command -v kubectl)" ] || ! [ -x "$(command -v eksctl)" ] || ! [ -x "$(command -v ssm-cli)" ]; then
   echo 'ERROR: tools not installed.' >&2


### PR DESCRIPTION
*Issue #, if available:*
The install-tools script is trying to get eksctl from weaveworks repo which returns 404.

*Description of changes:*
Since the install-tools script is trying to get eksctl from weaveworks repo which returns 404, So modified the script to download eksctl from eksctl-io github repo.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
