### PR TITLE
Update installtools.md

### DIFF
--- a/content/prerequisites/installtools.md
+++ b/content/prerequisites/installtools.md
@@ -29,7 +29,11 @@ sudo chmod +x /usr/local/bin/kubectl
 echo 'source <(kubectl completion bash)' >>~/.bashrc
 source ~/.bashrc
 
-curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+ARCH=amd64
+PLATFORM=$(uname -s)_$ARCH
+curl -sLO "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$PLATFORM.tar.gz"
+tar -xzf eksctl_$PLATFORM.tar.gz -C /tmp && rm eksctl_$PLATFORM.tar.gz
+
 sudo mv -v /tmp/eksctl /usr/local/bin
 
 if ! [ -x "$(command -v jq)" ] || ! [ -x "$(command -v envsubst)" ] || ! [ -x "$(command -v kubectl)" ] || ! [ -x "$(command -v eksctl)" ] || ! [ -x "$(command -v ssm-cli)" ]; then


### PR DESCRIPTION
Update the `eksctl` link for the workshop

Before:
```
workshop:~/environment $ ~/environment/scripts/install-tools
Last metadata expiration check: 0:50:01 ago on Mon Jun 10 19:45:51 2024.
Package jq-1.7.1-48.amzn2023.0.1.x86_64 is already installed.
Package gettext-0.21-4.amzn2023.0.2.x86_64 is already installed.
Package bash-completion-1:2.11-2.amzn2023.0.2.noarch is already installed.
Dependencies resolved.
Nothing to do.
Complete!
Last metadata expiration check: 0:50:03 ago on Mon Jun 10 19:45:51 2024.
Package session-manager-plugin-1.2.633.0-1.x86_64 is already installed.
Dependencies resolved.
Nothing to do.
Complete!

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
mv: cannot stat '/tmp/eksctl': No such file or directory
ERROR: tools not installed.
```

After:

workshop:~/environment $ ~/environment/scripts/install-tools Last metadata expiration check: 1:04:32 ago on Mon Jun 10 19:45:51 2024. Package jq-1.7.1-48.amzn2023.0.1.x86_64 is already installed. Package gettext-0.21-4.amzn2023.0.2.x86_64 is already installed. Package bash-completion-1:2.11-2.amzn2023.0.2.noarch is already installed. Dependencies resolved.
Nothing to do.
Complete!
Last metadata expiration check: 1:04:34 ago on Mon Jun 10 19:45:51 2024. Package session-manager-plugin-1.2.633.0-1.x86_64 is already installed. Dependencies resolved.
Nothing to do.
Complete!
copied '/tmp/eksctl' -> '/usr/local/bin/eksctl'
removed '/tmp/eksctl'
Requirement already satisfied: awscli in /usr/lib/python3.9/site-packages (2.15.30) Requirement already satisfied: colorama<0.4.7,>=0.2.5 in /usr/lib/python3.9/site-packages (from awscli) (0.4.4) Requirement already satisfied: python-dateutil<=2.8.2,>=2.1 in /usr/lib/python3.9/site-packages (from awscli) (2.8.1) Requirement already satisfied: prompt-toolkit<3.0.39,>=3.0.24 in /usr/lib/python3.9/site-packages (from awscli) (3.0.24) Requirement already satisfied: distro<1.9.0,>=1.5.0 in /usr/lib/python3.9/site-packages (from awscli) (1.5.0) Requirement already satisfied: ruamel.yaml<=0.17.21,>=0.15.0 in /usr/lib/python3.9/site-packages (from awscli) (0.16.6) Requirement already satisfied: cryptography<40.0.2,>=3.3.2 in /usr/lib64/python3.9/site-packages (from awscli) (36.0.1) Requirement already satisfied: awscrt<=0.19.19,>=0.19.18 in /usr/lib64/python3.9/site-packages (from awscli) (0.19.19) Requirement already satisfied: urllib3<1.27,>=1.25.4 in /usr/lib/python3.9/site-packages (from awscli) (1.25.10) Requirement already satisfied: jmespath<1.1.0,>=0.7.1 in /usr/lib/python3.9/site-packages (from awscli) (0.10.0) Requirement already satisfied: docutils<0.20,>=0.10 in /usr/lib/python3.9/site-packages (from awscli) (0.16) Requirement already satisfied: cffi>=1.12 in /usr/lib64/python3.9/site-packages (from cryptography<40.0.2,>=3.3.2->awscli) (1.14.5) Requirement already satisfied: wcwidth in /usr/lib/python3.9/site-packages (from prompt-toolkit<3.0.39,>=3.0.24->awscli) (0.2.5) Requirement already satisfied: six>=1.5 in /usr/lib/python3.9/site-packages (from python-dateutil<=2.8.2,>=2.1->awscli) (1.15.0) Requirement already satisfied: pycparser in /usr/lib/python3.9/site-packages (from cffi>=1.12->cryptography<40.0.2,>=3.3.2->awscli) (2.20) Requirement already satisfied: ply==3.11 in /usr/lib/python3.9/site-packages (from pycparser->cffi>=1.12->cryptography<40.0.2,>=3.3.2->awscli) (3.11)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
